### PR TITLE
Clean up build and dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,3 @@
 /.travis.coverage.sh export-ignore
 /.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
-/README.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,5 @@
-# Ignore Eclipse files
-.buildpath
-.project
-.settings/
-
 # build files
 vendor/
 composer.lock
 /phpunit.xml
 /build
-
-# bad
-*.DS_Store

--- a/.travis.coverage.sh
+++ b/.travis.coverage.sh
@@ -1,6 +1,0 @@
-set -x
-if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ] || [ "$TRAVIS_PHP_VERSION" = 'hhvm-nightly' ] ; then
-    echo "skipping coverage submission for HHVM builds"
-else
-  php vendor/bin/coveralls
-fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - composer install --prefer-stable
+  - composer install --prefer-dist
 
 script:
   - mkdir -p build/logs
@@ -20,6 +20,4 @@ script:
   - composer style
 
 after_script:
-  - sh .travis.coverage.sh
-  - composer check
-  - composer metrics
+  - composer coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - composer update --prefer-stable
+  - composer install --prefer-stable
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,7 @@
     "require-dev": {
         "phpunit/phpunit":           "@stable",
         "satooshi/php-coveralls":    "@stable",
-        "squizlabs/php_codesniffer": "@stable",
-        "phpmd/phpmd":               "@stable",
-        "phpmetrics/phpmetrics":     "@stable"
+        "squizlabs/php_codesniffer": "@stable"
     },
     "autoload": {
         "psr-4": { "texdc\\range\\": "src/" }
@@ -23,9 +21,8 @@
         "psr-4": { "texdc\\range\\test\\": "test/" }
     },
     "scripts": {
-        "test":    "vendor/bin/phpunit",
-        "style":   "vendor/bin/phpcs --standard=PSR2 src/ test/",
-        "check":   "vendor/bin/phpmd src/,test/ text cleancode,codesize,design,naming,unusedcode",
-        "metrics": "vendor/bin/phpmetrics --report-cli src/"
+        "test":     "vendor/bin/phpunit",
+        "style":    "vendor/bin/phpcs --standard=PSR2 src/ test/",
+        "coverage": "vendor/bin/php-coveralls"
     }
 }

--- a/src/AbstractRange.php
+++ b/src/AbstractRange.php
@@ -203,7 +203,10 @@ abstract class AbstractRange implements RangeInterface
      */
     public function findGapTo(self $another) : self
     {
-        if ($this->abuts($another) || $this->contains($another) || $another->contains($this) || $this->overlaps($another)) {
+        if ($this->abuts($another)
+                || $this->contains($another)
+                || $another->contains($this)
+                || $this->overlaps($another)) {
             return static::void();
         } elseif ($this->isContraryTo($another)) {
             return $this->findContraryGap($another);


### PR DESCRIPTION
No longer seeing the value of `phpmd` and `phpmetrics`.  Addressed style warning.  Removed legacy hhvm coverage script.